### PR TITLE
JWT トークンの有効期限を延長し、API プレフィックスを統一

### DIFF
--- a/apps/server/app/constants.py
+++ b/apps/server/app/constants.py
@@ -19,7 +19,7 @@ DEFAULT_DATABASE_URL = 'postgres://postgres:password@localhost:5432/echo_bird'
 
 # JWT 設定
 JWT_ALGORITHM = 'HS256'
-JWT_ACCESS_TOKEN_EXPIRE_MINUTES = 30
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES = 360  # 6時間 (360分)
 JWT_SECRET_KEY = 'your-secret-key-here'  # 本番環境では環境変数から取得
 
 

--- a/apps/server/app/routers/auth.py
+++ b/apps/server/app/routers/auth.py
@@ -3,10 +3,11 @@ from datetime import timedelta
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict
 
+from app.constants import API_PREFIX, JWT_ACCESS_TOKEN_EXPIRE_MINUTES
 from app.models.user import User
 from app.utils.auth import authenticate_user, create_access_token, get_current_user
 
-router = APIRouter(prefix='/api/v1/auth', tags=['auth'])
+router = APIRouter(prefix=f'{API_PREFIX}/auth', tags=['auth'])
 
 
 class LoginRequest(BaseModel):
@@ -47,7 +48,7 @@ async def LoginAPI(request: LoginRequest) -> TokenResponse:
             headers={'WWW-Authenticate': 'Bearer'},
         )
 
-    access_token_expires = timedelta(minutes=30)
+    access_token_expires = timedelta(minutes=JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
         data={'sub': str(user.id)}, expires_delta=access_token_expires
     )


### PR DESCRIPTION
## 概要
JWT アクセストークンの有効期限を延長し、API エンドポイントの定義を統一しました。

## 変更内容
- JWT アクセストークンの有効期限を 30 分から 6 時間（360分）に延長
  - ユーザーがより長時間ログイン状態を維持できるようになります
- `auth.py` で `API_PREFIX` 定数を使用するように修正
  - API エンドポイントの定義の一貫性が向上しました

## テストプラン
- [ ] ログイン機能が正常に動作することを確認
- [ ] トークンの有効期限が 6 時間に設定されていることを確認
- [ ] API エンドポイントが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)