### PR TITLE
ブックマーク時にツイートメディアを MinIO に自動保存

### DIFF
--- a/apps/server/app/routers/tweets.py
+++ b/apps/server/app/routers/tweets.py
@@ -566,6 +566,6 @@ async def _process_tweet_media_for_bookmark(tweet: Tweet) -> None:
                 # バックグラウンドタスクとして実行（awaitしない）
                 asyncio.create_task(
                     _process_single_media_background(
-                        media.id, media.media_key, tweet.tweet_id
+                        media.id, media.media_key, quoted_tweet.tweet_id
                     )
                 )


### PR DESCRIPTION
## 概要

ブックマーク機能を拡張し、ツイートをブックマークした際に、そのツイートに含まれるメディアファイル（画像・動画・GIF）を自動的に MinIO に保存する機能を実装しました。

## 主な変更内容

- **ブックマーク API の拡張**: `ToggleBookmarkAPI` にメディア自動保存処理を追加
- **メディア処理関数の実装**: `_process_tweet_media_for_bookmark()` 関数を新規作成
- **引用ツイート対応**: 引用ツイート内のメディアも自動的に保存対象に含める
- **非同期処理**: メディアダウンロードはバックグラウンドで実行し、ブックマーク操作をブロックしない
- **エラーハンドリング**: メディア処理に失敗してもブックマーク機能は正常動作を維持

## 実装詳細

### 動作フロー
1. ユーザーがツイートをブックマーク
2. ブックマーク情報をデータベースに保存
3. ツイート本体のメディアを特定・ダウンロード開始
4. 引用ツイートがある場合、そのメディアもダウンロード開始
5. すべて非同期で処理され、ユーザーにはすぐにレスポンスを返却

### 技術的特徴
- **既存機能の活用**: 既存のメディアダウンローダーと MinIO クライアントを統合利用
- **重複処理防止**: 既にダウンロード済みのメディアは自動的にスキップ
- **堅牢性**: エラー発生時もログ記録し、メイン機能は継続動作
- **拡張性**: 既存のメディア管理 API との連携により、失敗したダウンロードのリトライも可能

## テスト

- 機能の動作確認テストを実装・実行済み
- メインツイートと引用ツイートの両方のメディア処理をテスト
- エラーハンドリングの動作も確認済み

## 影響範囲

- **サーバー側**: `app/routers/tweets.py` のみを変更
- **既存機能への影響**: なし（既存のブックマーク機能はそのまま動作）
- **パフォーマンス**: メディア処理は非同期のためユーザー体験に影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)