### PR TITLE
タイムライン詳細ページのネストルーティング対応

### DIFF
--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -22,13 +22,14 @@ import { Route as TargetAccountsIndexImport } from './routes/target-accounts.ind
 import { Route as TwitterAccountsCreateImport } from './routes/twitter-accounts.create'
 import { Route as TwitterAccountsAccountIdImport } from './routes/twitter-accounts.$accountId'
 import { Route as TimelinesCreateImport } from './routes/timelines.create'
-import { Route as TimelinesTimelineIdImport } from './routes/timelines.$timelineId'
 import { Route as TestApiImport } from './routes/test.api'
 import { Route as TargetAccountsCreateImport } from './routes/target-accounts.create'
 import { Route as TargetAccountsAccountIdImport } from './routes/target-accounts.$accountId'
 import { Route as DemoTanstackQueryImport } from './routes/demo.tanstack-query'
 import { Route as DemoStoreImport } from './routes/demo.store'
+import { Route as TimelinesTimelineIdIndexImport } from './routes/timelines.$timelineId.index'
 import { Route as AdminUsersIndexImport } from './routes/admin.users.index'
+import { Route as TimelinesTimelineIdEditImport } from './routes/timelines.$timelineId.edit'
 import { Route as AdminUsersCreateImport } from './routes/admin.users.create'
 import { Route as AdminUsersUserIdImport } from './routes/admin.users.$userId'
 
@@ -100,12 +101,6 @@ const TimelinesCreateRoute = TimelinesCreateImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
-const TimelinesTimelineIdRoute = TimelinesTimelineIdImport.update({
-  id: '/timelines/$timelineId',
-  path: '/timelines/$timelineId',
-  getParentRoute: () => rootRoute,
-} as any)
-
 const TestApiRoute = TestApiImport.update({
   id: '/test/api',
   path: '/test/api',
@@ -136,9 +131,21 @@ const DemoStoreRoute = DemoStoreImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const TimelinesTimelineIdIndexRoute = TimelinesTimelineIdIndexImport.update({
+  id: '/timelines/$timelineId/',
+  path: '/timelines/$timelineId/',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const AdminUsersIndexRoute = AdminUsersIndexImport.update({
   id: '/admin/users/',
   path: '/admin/users/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const TimelinesTimelineIdEditRoute = TimelinesTimelineIdEditImport.update({
+  id: '/timelines/$timelineId/edit',
+  path: '/timelines/$timelineId/edit',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -228,13 +235,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TestApiImport
       parentRoute: typeof rootRoute
     }
-    '/timelines/$timelineId': {
-      id: '/timelines/$timelineId'
-      path: '/timelines/$timelineId'
-      fullPath: '/timelines/$timelineId'
-      preLoaderRoute: typeof TimelinesTimelineIdImport
-      parentRoute: typeof rootRoute
-    }
     '/timelines/create': {
       id: '/timelines/create'
       path: '/timelines/create'
@@ -291,11 +291,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminUsersCreateImport
       parentRoute: typeof rootRoute
     }
+    '/timelines/$timelineId/edit': {
+      id: '/timelines/$timelineId/edit'
+      path: '/timelines/$timelineId/edit'
+      fullPath: '/timelines/$timelineId/edit'
+      preLoaderRoute: typeof TimelinesTimelineIdEditImport
+      parentRoute: typeof rootRoute
+    }
     '/admin/users/': {
       id: '/admin/users/'
       path: '/admin/users'
       fullPath: '/admin/users'
       preLoaderRoute: typeof AdminUsersIndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/timelines/$timelineId/': {
+      id: '/timelines/$timelineId/'
+      path: '/timelines/$timelineId'
+      fullPath: '/timelines/$timelineId'
+      preLoaderRoute: typeof TimelinesTimelineIdIndexImport
       parentRoute: typeof rootRoute
     }
   }
@@ -314,7 +328,6 @@ export interface FileRoutesByFullPath {
   '/target-accounts/$accountId': typeof TargetAccountsAccountIdRoute
   '/target-accounts/create': typeof TargetAccountsCreateRoute
   '/test/api': typeof TestApiRoute
-  '/timelines/$timelineId': typeof TimelinesTimelineIdRoute
   '/timelines/create': typeof TimelinesCreateRoute
   '/twitter-accounts/$accountId': typeof TwitterAccountsAccountIdRoute
   '/twitter-accounts/create': typeof TwitterAccountsCreateRoute
@@ -323,7 +336,9 @@ export interface FileRoutesByFullPath {
   '/twitter-accounts': typeof TwitterAccountsIndexRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/admin/users/create': typeof AdminUsersCreateRoute
+  '/timelines/$timelineId/edit': typeof TimelinesTimelineIdEditRoute
   '/admin/users': typeof AdminUsersIndexRoute
+  '/timelines/$timelineId': typeof TimelinesTimelineIdIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -337,7 +352,6 @@ export interface FileRoutesByTo {
   '/target-accounts/$accountId': typeof TargetAccountsAccountIdRoute
   '/target-accounts/create': typeof TargetAccountsCreateRoute
   '/test/api': typeof TestApiRoute
-  '/timelines/$timelineId': typeof TimelinesTimelineIdRoute
   '/timelines/create': typeof TimelinesCreateRoute
   '/twitter-accounts/$accountId': typeof TwitterAccountsAccountIdRoute
   '/twitter-accounts/create': typeof TwitterAccountsCreateRoute
@@ -346,7 +360,9 @@ export interface FileRoutesByTo {
   '/twitter-accounts': typeof TwitterAccountsIndexRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/admin/users/create': typeof AdminUsersCreateRoute
+  '/timelines/$timelineId/edit': typeof TimelinesTimelineIdEditRoute
   '/admin/users': typeof AdminUsersIndexRoute
+  '/timelines/$timelineId': typeof TimelinesTimelineIdIndexRoute
 }
 
 export interface FileRoutesById {
@@ -361,7 +377,6 @@ export interface FileRoutesById {
   '/target-accounts/$accountId': typeof TargetAccountsAccountIdRoute
   '/target-accounts/create': typeof TargetAccountsCreateRoute
   '/test/api': typeof TestApiRoute
-  '/timelines/$timelineId': typeof TimelinesTimelineIdRoute
   '/timelines/create': typeof TimelinesCreateRoute
   '/twitter-accounts/$accountId': typeof TwitterAccountsAccountIdRoute
   '/twitter-accounts/create': typeof TwitterAccountsCreateRoute
@@ -370,7 +385,9 @@ export interface FileRoutesById {
   '/twitter-accounts/': typeof TwitterAccountsIndexRoute
   '/admin/users/$userId': typeof AdminUsersUserIdRoute
   '/admin/users/create': typeof AdminUsersCreateRoute
+  '/timelines/$timelineId/edit': typeof TimelinesTimelineIdEditRoute
   '/admin/users/': typeof AdminUsersIndexRoute
+  '/timelines/$timelineId/': typeof TimelinesTimelineIdIndexRoute
 }
 
 export interface FileRouteTypes {
@@ -386,7 +403,6 @@ export interface FileRouteTypes {
     | '/target-accounts/$accountId'
     | '/target-accounts/create'
     | '/test/api'
-    | '/timelines/$timelineId'
     | '/timelines/create'
     | '/twitter-accounts/$accountId'
     | '/twitter-accounts/create'
@@ -395,7 +411,9 @@ export interface FileRouteTypes {
     | '/twitter-accounts'
     | '/admin/users/$userId'
     | '/admin/users/create'
+    | '/timelines/$timelineId/edit'
     | '/admin/users'
+    | '/timelines/$timelineId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -408,7 +426,6 @@ export interface FileRouteTypes {
     | '/target-accounts/$accountId'
     | '/target-accounts/create'
     | '/test/api'
-    | '/timelines/$timelineId'
     | '/timelines/create'
     | '/twitter-accounts/$accountId'
     | '/twitter-accounts/create'
@@ -417,7 +434,9 @@ export interface FileRouteTypes {
     | '/twitter-accounts'
     | '/admin/users/$userId'
     | '/admin/users/create'
+    | '/timelines/$timelineId/edit'
     | '/admin/users'
+    | '/timelines/$timelineId'
   id:
     | '__root__'
     | '/'
@@ -430,7 +449,6 @@ export interface FileRouteTypes {
     | '/target-accounts/$accountId'
     | '/target-accounts/create'
     | '/test/api'
-    | '/timelines/$timelineId'
     | '/timelines/create'
     | '/twitter-accounts/$accountId'
     | '/twitter-accounts/create'
@@ -439,7 +457,9 @@ export interface FileRouteTypes {
     | '/twitter-accounts/'
     | '/admin/users/$userId'
     | '/admin/users/create'
+    | '/timelines/$timelineId/edit'
     | '/admin/users/'
+    | '/timelines/$timelineId/'
   fileRoutesById: FileRoutesById
 }
 
@@ -454,7 +474,6 @@ export interface RootRouteChildren {
   TargetAccountsAccountIdRoute: typeof TargetAccountsAccountIdRoute
   TargetAccountsCreateRoute: typeof TargetAccountsCreateRoute
   TestApiRoute: typeof TestApiRoute
-  TimelinesTimelineIdRoute: typeof TimelinesTimelineIdRoute
   TimelinesCreateRoute: typeof TimelinesCreateRoute
   TwitterAccountsAccountIdRoute: typeof TwitterAccountsAccountIdRoute
   TwitterAccountsCreateRoute: typeof TwitterAccountsCreateRoute
@@ -463,7 +482,9 @@ export interface RootRouteChildren {
   TwitterAccountsIndexRoute: typeof TwitterAccountsIndexRoute
   AdminUsersUserIdRoute: typeof AdminUsersUserIdRoute
   AdminUsersCreateRoute: typeof AdminUsersCreateRoute
+  TimelinesTimelineIdEditRoute: typeof TimelinesTimelineIdEditRoute
   AdminUsersIndexRoute: typeof AdminUsersIndexRoute
+  TimelinesTimelineIdIndexRoute: typeof TimelinesTimelineIdIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -477,7 +498,6 @@ const rootRouteChildren: RootRouteChildren = {
   TargetAccountsAccountIdRoute: TargetAccountsAccountIdRoute,
   TargetAccountsCreateRoute: TargetAccountsCreateRoute,
   TestApiRoute: TestApiRoute,
-  TimelinesTimelineIdRoute: TimelinesTimelineIdRoute,
   TimelinesCreateRoute: TimelinesCreateRoute,
   TwitterAccountsAccountIdRoute: TwitterAccountsAccountIdRoute,
   TwitterAccountsCreateRoute: TwitterAccountsCreateRoute,
@@ -486,7 +506,9 @@ const rootRouteChildren: RootRouteChildren = {
   TwitterAccountsIndexRoute: TwitterAccountsIndexRoute,
   AdminUsersUserIdRoute: AdminUsersUserIdRoute,
   AdminUsersCreateRoute: AdminUsersCreateRoute,
+  TimelinesTimelineIdEditRoute: TimelinesTimelineIdEditRoute,
   AdminUsersIndexRoute: AdminUsersIndexRoute,
+  TimelinesTimelineIdIndexRoute: TimelinesTimelineIdIndexRoute,
 }
 
 export const routeTree = rootRoute
@@ -509,7 +531,6 @@ export const routeTree = rootRoute
         "/target-accounts/$accountId",
         "/target-accounts/create",
         "/test/api",
-        "/timelines/$timelineId",
         "/timelines/create",
         "/twitter-accounts/$accountId",
         "/twitter-accounts/create",
@@ -518,7 +539,9 @@ export const routeTree = rootRoute
         "/twitter-accounts/",
         "/admin/users/$userId",
         "/admin/users/create",
-        "/admin/users/"
+        "/timelines/$timelineId/edit",
+        "/admin/users/",
+        "/timelines/$timelineId/"
       ]
     },
     "/": {
@@ -551,9 +574,6 @@ export const routeTree = rootRoute
     "/test/api": {
       "filePath": "test.api.tsx"
     },
-    "/timelines/$timelineId": {
-      "filePath": "timelines.$timelineId.tsx"
-    },
     "/timelines/create": {
       "filePath": "timelines.create.tsx"
     },
@@ -578,8 +598,14 @@ export const routeTree = rootRoute
     "/admin/users/create": {
       "filePath": "admin.users.create.tsx"
     },
+    "/timelines/$timelineId/edit": {
+      "filePath": "timelines.$timelineId.edit.tsx"
+    },
     "/admin/users/": {
       "filePath": "admin.users.index.tsx"
+    },
+    "/timelines/$timelineId/": {
+      "filePath": "timelines.$timelineId.index.tsx"
     }
   }
 }

--- a/apps/client/src/routes/timelines.$timelineId.edit.tsx
+++ b/apps/client/src/routes/timelines.$timelineId.edit.tsx
@@ -1,0 +1,326 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { targetAccountListQueryOptions } from '../integrations/tanstack-query/queries/target-account';
+import {
+  timelineDetailQueryOptions,
+  useUpdateTimelineMutation,
+} from '../integrations/tanstack-query/queries/timeline';
+import {
+  buttonGroup,
+  cancelButton,
+  checkbox,
+  checkboxLabel,
+  errorMessage,
+  formContainer,
+  formGroup,
+  formHeader,
+  input,
+  label,
+  submitButton,
+  textarea,
+} from '../styles/admin-form.css';
+
+export const Route = createFileRoute('/timelines/$timelineId/edit')({
+  loader: ({ context, params }: { context: any; params: any }) => {
+    const timelineId = Number.parseInt(params.timelineId);
+    return Promise.all([
+      context.queryClient.ensureQueryData(
+        timelineDetailQueryOptions(timelineId),
+      ),
+      context.queryClient.ensureQueryData(targetAccountListQueryOptions),
+    ]);
+  },
+  component: EditTimeline,
+});
+
+function EditTimeline() {
+  const navigate = useNavigate();
+  const { timelineId } = Route.useParams();
+
+  // データ取得
+  const { data: timeline } = useSuspenseQuery(
+    timelineDetailQueryOptions(Number.parseInt(timelineId)),
+  );
+  const { data: targetAccountsData } = useSuspenseQuery(
+    targetAccountListQueryOptions,
+  );
+  const updateTimelineMutation = useUpdateTimelineMutation();
+
+  // フォーム状態
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    target_account_ids: [] as number[],
+    is_active: true,
+    is_default: false,
+  });
+
+  const [error, setError] = useState<string | null>(null);
+
+  // タイムラインデータでフォームを初期化
+  useEffect(() => {
+    if (timeline) {
+      setFormData({
+        name: timeline.name,
+        description: timeline.description || '',
+        target_account_ids: timeline.target_accounts.map((account) => account.id),
+        is_active: timeline.is_active,
+        is_default: timeline.is_default,
+      });
+    }
+  }, [timeline]);
+
+  // フォーム送信
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    // バリデーション
+    if (!formData.name.trim()) {
+      setError('タイムライン名を入力してください。');
+      return;
+    }
+
+    if (formData.target_account_ids.length === 0) {
+      setError('少なくとも1つのターゲットアカウントを選択してください。');
+      return;
+    }
+
+    try {
+      await updateTimelineMutation.mutateAsync({
+        timelineId: Number.parseInt(timelineId),
+        data: {
+          name: formData.name.trim(),
+          description: formData.description.trim() || null,
+          target_account_ids: formData.target_account_ids,
+          is_active: formData.is_active,
+          is_default: formData.is_default,
+        },
+      });
+
+      alert('タイムラインを更新しました');
+      navigate({ to: '/timelines' });
+    } catch (error) {
+      console.error('Failed to update timeline:', error);
+      setError('タイムラインの更新に失敗しました。');
+    }
+  };
+
+  // ターゲットアカウント選択の切り替え
+  const handleTargetAccountToggle = (accountId: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      target_account_ids: prev.target_account_ids.includes(accountId)
+        ? prev.target_account_ids.filter((id) => id !== accountId)
+        : [...prev.target_account_ids, accountId],
+    }));
+  };
+
+  return (
+    <div className={formContainer}>
+      <div className={formHeader}>
+        <h1>タイムライン「{timeline.name}」を編集</h1>
+        <p>
+          タイムラインの設定やターゲットアカウントを変更できます。
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        {/* タイムライン名 */}
+        <div className={formGroup}>
+          <label className={label}>
+            タイムライン名 <span style={{ color: 'red' }}>*</span>
+          </label>
+          <input
+            type="text"
+            value={formData.name}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, name: e.target.value }))
+            }
+            placeholder="例: 技術系アカウント"
+            className={input}
+            maxLength={255}
+            required
+          />
+        </div>
+
+        {/* 説明 */}
+        <div className={formGroup}>
+          <label className={label}>説明（任意）</label>
+          <textarea
+            value={formData.description}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, description: e.target.value }))
+            }
+            placeholder="このタイムラインについての説明を入力してください..."
+            className={textarea}
+            rows={3}
+          />
+        </div>
+
+        {/* ターゲットアカウント選択 */}
+        <div className={formGroup}>
+          <label className={label}>
+            ターゲットアカウント <span style={{ color: 'red' }}>*</span>
+          </label>
+          <p
+            style={{
+              fontSize: '0.875rem',
+              color: '#666',
+              marginBottom: '1rem',
+            }}
+          >
+            タイムラインに含めるターゲットアカウントを選択してください（複数選択可能）
+          </p>
+
+          <div
+            style={{
+              maxHeight: '300px',
+              overflowY: 'auto',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              padding: '1rem',
+            }}
+          >
+            {targetAccountsData.accounts.length > 0 ? (
+              targetAccountsData.accounts.map((account) => (
+                <label key={account.id} className={checkboxLabel}>
+                  <input
+                    type="checkbox"
+                    checked={formData.target_account_ids.includes(account.id)}
+                    onChange={() => handleTargetAccountToggle(account.id)}
+                    className={checkbox}
+                  />
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                    }}
+                  >
+                    {account.profile_image_url && (
+                      <img
+                        src={account.profile_image_url}
+                        alt={account.username}
+                        style={{
+                          width: '24px',
+                          height: '24px',
+                          borderRadius: '50%',
+                        }}
+                      />
+                    )}
+                    <span>
+                      @{account.username}
+                      {account.display_name && ` (${account.display_name})`}
+                    </span>
+                    {!account.is_active && (
+                      <span
+                        style={{
+                          fontSize: '12px',
+                          color: '#f44336',
+                          fontWeight: 'bold',
+                        }}
+                      >
+                        非アクティブ
+                      </span>
+                    )}
+                  </div>
+                </label>
+              ))
+            ) : (
+              <p style={{ color: '#666', textAlign: 'center' }}>
+                ターゲットアカウントが登録されていません。
+                <br />
+                <a href="/target-accounts/create" style={{ color: '#2196F3' }}>
+                  ターゲットアカウントを追加
+                </a>
+                してください。
+              </p>
+            )}
+          </div>
+
+          {formData.target_account_ids.length > 0 && (
+            <p
+              style={{
+                fontSize: '0.875rem',
+                color: '#666',
+                marginTop: '0.5rem',
+              }}
+            >
+              {formData.target_account_ids.length}個のアカウントを選択中
+            </p>
+          )}
+        </div>
+
+        {/* オプション設定 */}
+        <div className={formGroup}>
+          <label className={label}>オプション</label>
+
+          <label className={checkboxLabel}>
+            <input
+              type="checkbox"
+              checked={formData.is_active}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  is_active: e.target.checked,
+                }))
+              }
+              className={checkbox}
+            />
+            アクティブ状態
+            <span
+              style={{ fontSize: '0.875rem', color: '#666', marginLeft: '8px' }}
+            >
+              （アクティブでないタイムラインは表示されません）
+            </span>
+          </label>
+
+          <label className={checkboxLabel}>
+            <input
+              type="checkbox"
+              checked={formData.is_default}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  is_default: e.target.checked,
+                }))
+              }
+              className={checkbox}
+            />
+            デフォルトタイムライン
+            <span
+              style={{ fontSize: '0.875rem', color: '#666', marginLeft: '8px' }}
+            >
+              （メインのタイムラインとして使用）
+            </span>
+          </label>
+        </div>
+
+        {/* エラーメッセージ */}
+        {error && <div className={errorMessage}>{error}</div>}
+
+        {/* ボタン */}
+        <div className={buttonGroup}>
+          <button
+            type="submit"
+            disabled={updateTimelineMutation.isPending}
+            className={submitButton}
+          >
+            {updateTimelineMutation.isPending
+              ? '更新中...'
+              : 'タイムラインを更新'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate({ to: '/timelines' })}
+            className={cancelButton}
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/client/src/routes/timelines.$timelineId.index.tsx
+++ b/apps/client/src/routes/timelines.$timelineId.index.tsx
@@ -9,7 +9,7 @@ import {
 import { container, header, headerControls } from '../styles/admin.css';
 import { TweetItem } from '../components/TweetItem';
 
-export const Route = createFileRoute('/timelines/$timelineId')({
+export const Route = createFileRoute('/timelines/$timelineId/')({
   loader: ({ context, params }) => {
     const timelineId = Number.parseInt(params.timelineId);
     return Promise.all([


### PR DESCRIPTION
## 概要
タイムライン詳細ページをネストルーティング構造にリファクタリングしました。

- `/timelines/$timelineId` → `/timelines/$timelineId/` (詳細表示)
- `/timelines/$timelineId/edit` (編集画面)

## 変更内容
- `timelines.$timelineId.tsx`を削除し、以下の2つのファイルに分割：
  - `timelines.$timelineId.index.tsx` - タイムライン詳細表示
  - `timelines.$timelineId.edit.tsx` - タイムライン編集画面
- TanStack Routerのルートツリー設定を更新
- ネストルーティングに対応したURL構造に変更

## テスト計画
- [ ] タイムライン一覧からタイムライン詳細への遷移が正常に動作すること
- [ ] タイムライン詳細から編集画面への遷移が正常に動作すること  
- [ ] 編集画面での保存・キャンセル機能が正常に動作すること
- [ ] URLの直接アクセスでも正常に表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)