### PR TITLE
feat: Docker Compose環境でClient/Serverを完全対応

### DIFF
--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,0 +1,25 @@
+# Client用のDockerfile
+# Node.js 22を使用してReact + TypeScriptアプリケーションをビルド・実行
+
+FROM node:22-alpine AS base
+
+# pnpmをインストール
+RUN npm install -g pnpm
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# package.jsonとpnpm-lock.yamlをコピー
+COPY package.json pnpm-lock.yaml ./
+
+# 依存関係をインストール
+RUN pnpm install --frozen-lockfile
+
+# ソースコードをコピー
+COPY . .
+
+# 開発用のポート3000を公開
+EXPOSE 3000
+
+# 開発サーバーを起動
+CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]

--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -15,12 +15,14 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        // Docker環境では server:8000、ローカルでは localhost:8000 を使用
+        target: process.env.VITE_API_TARGET || 'http://localhost:8000',
         changeOrigin: true,
         secure: false,
       },
       '/health': {
-        target: 'http://localhost:8000',
+        // Docker環境では server:8000、ローカルでは localhost:8000 を使用
+        target: process.env.VITE_API_TARGET || 'http://localhost:8000',
         changeOrigin: true,
         secure: false,
       },

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,32 @@
+# Server用のDockerfile
+# Python 3.11を使用してFastAPI + Tortoise ORMアプリケーションを実行
+
+FROM python:3.11-slim
+
+# uvをインストール
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# Python環境を設定
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+# pyproject.tomlとuv.lockをコピー
+COPY pyproject.toml uv.lock ./
+
+# 依存関係をインストール
+RUN uv sync --frozen --no-install-project --no-dev
+
+# ソースコードをコピー
+COPY . .
+
+# プロジェクトをインストール
+RUN uv sync --frozen --no-dev
+
+# ポート8000を公開
+EXPOSE 8000
+
+# FastAPIサーバーを起動
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -43,13 +44,21 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(lifespan=lifespan, title=APP_NAME, version=APP_VERSION)
 
-# CORS設定 - 開発環境用
+# CORS設定 - 開発環境用（ローカル・Docker対応）
+allowed_origins = [
+    'http://localhost:5173',  # Vite開発サーバー（ローカル）
+    'http://127.0.0.1:5173',
+    'http://localhost:3000',  # Docker環境でのClient
+    'http://127.0.0.1:3000',
+]
+
+# 環境変数で追加のオリジンを指定可能
+if cors_origins := os.environ.get('CORS_ORIGINS'):
+    allowed_origins.extend(cors_origins.split(','))
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        'http://localhost:5173',  # Vite開発サーバー
-        'http://127.0.0.1:5173',
-    ],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=['*'],
     allow_headers=['*'],

--- a/apps/server/app/utils/s3_client.py
+++ b/apps/server/app/utils/s3_client.py
@@ -18,7 +18,10 @@ class S3Client:
 
     def __init__(self):
         """S3クライアントを初期化"""
+        # サーバー間通信用エンドポイント（コンテナ名使用）
         self.endpoint_url = os.getenv('MINIO_ENDPOINT_URL', 'http://localhost:9000')
+        # ブラウザ向けパブリックアクセス用エンドポイント（localhostを使用）
+        self.public_endpoint_url = os.getenv('MINIO_PUBLIC_ENDPOINT_URL', 'http://localhost:9000')
         self.access_key = os.getenv('MINIO_ACCESS_KEY', 'minioadmin')
         self.secret_key = os.getenv('MINIO_SECRET_KEY', 'minioadmin123')
         self.region_name = os.getenv('MINIO_REGION', 'us-east-1')
@@ -165,8 +168,8 @@ class S3Client:
             return False
 
     def get_public_url(self, bucket_name: str, object_key: str) -> str:
-        """パブリックアクセス用の直接URLを生成する"""
-        return f'{self.endpoint_url}/{bucket_name}/{object_key}'
+        """パブリックアクセス用の直接URLを生成する（ブラウザからアクセス可能）"""
+        return f'{self.public_endpoint_url}/{bucket_name}/{object_key}'
 
     async def file_exists(self, bucket_name: str, object_key: str) -> bool:
         """ファイルがMinIOに存在するかチェックする"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,14 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
+    environment:
+      # ViteプロキシでServerコンテナにアクセスするための設定
+      VITE_API_TARGET: http://server:8000
     volumes:
       - ./apps/client:/app
       - /app/node_modules
+    depends_on:
+      - server
     networks:
       - echo-bird-network
     stdin_open: true
@@ -77,9 +82,12 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgres://postgres:password@postgres:5432/echo_bird
-      MINIO_ENDPOINT: minio:9000
+      # MinIO設定（S3Clientコードに合わせた環境変数名）
+      MINIO_ENDPOINT_URL: http://minio:9000  # サーバー間通信用
+      MINIO_PUBLIC_ENDPOINT_URL: http://localhost:9000  # ブラウザアクセス用
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin123
+      MINIO_REGION: us-east-1
     volumes:
       - ./apps/server:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,22 +49,46 @@ services:
       retries: 3
       start_period: 40s
 
-  # 将来的にサーバーもDockerizeする場合用
-  # server:
-  #   build:
-  #     context: ./apps/server
-  #     dockerfile: Dockerfile
-  #   container_name: echo-bird-server
-  #   restart: unless-stopped
-  #   ports:
-  #     - "8000:8000"
-  #   environment:
-  #     DATABASE_URL: postgres://postgres:password@postgres:5432/echo_bird
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
-  #   networks:
-  #     - echo-bird-network
+  # Client サービス (React + TypeScript)
+  client:
+    build:
+      context: ./apps/client
+      dockerfile: Dockerfile
+    container_name: echo-bird-client
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./apps/client:/app
+      - /app/node_modules
+    networks:
+      - echo-bird-network
+    stdin_open: true
+    tty: true
+
+  # Server サービス (FastAPI + Python)
+  server:
+    build:
+      context: ./apps/server
+      dockerfile: Dockerfile
+    container_name: echo-bird-server
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgres://postgres:password@postgres:5432/echo_bird
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+    volumes:
+      - ./apps/server:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    networks:
+      - echo-bird-network
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## 概要

ClientとServerの両方をDocker Composeで起動できる完全な開発環境を構築しました。既存のPostgreSQLとMinIOサービスと連携し、ローカル開発環境とDocker環境の両方に対応しています。

## 主な変更

### 🐳 Docker化対応
- **Client用Dockerfile**: Node.js 22 + pnpmを使用するReactアプリケーション用
- **Server用Dockerfile**: Python 3.11 + uvを使用するFastAPIアプリケーション用
- **docker-compose.yml**: clientとserverサービスを追加し、適切な依存関係を設定

### 🔗 コンテナ間通信の最適化
- **Viteプロキシ設定**: `VITE_API_TARGET`環境変数でDocker/ローカル環境を自動切り替え
- **CORS設定**: Docker環境のclient (`localhost:3000`) を許可リストに追加
- **依存関係管理**: healthcheckによる適切なサービス起動順序を実装

### 📁 MinIO設定の改善
- **二重エンドポイント対応**: 
  - `MINIO_ENDPOINT_URL`: `http://minio:9000` (サーバー間通信用)
  - `MINIO_PUBLIC_ENDPOINT_URL`: `http://localhost:9000` (ブラウザアクセス用)
- **S3Client更新**: パブリックURL生成時にブラウザからアクセス可能なエンドポイントを使用

## 動作確認

### ✅ コンテナ間通信テスト
- Client ↔ Server: Viteプロキシ経由で正常通信
- Server ↔ PostgreSQL: DB接続とhealthcheck正常
- Server ↔ MinIO: S3互換API経由でバケット操作正常
- Browser ↔ MinIO: メディアファイルへの直接アクセス正常

### ✅ アクセス確認
```bash
# API Health Check
$ curl http://localhost:3000/api/v1/health
{"status":"ok"}

# MinIO疎通テスト  
$ curl http://localhost:9000/tweet-media/media/test-docker.txt
Hello MinIO from Docker\!
```

## 使用方法

```bash
# 全サービス起動
docker-compose up

# 個別サービス起動
docker-compose up client server postgres minio

# ログ確認
docker-compose logs -f client
docker-compose logs -f server
```

### アクセスポイント
- **Client**: http://localhost:3000
- **Server API**: http://localhost:8000
- **MinIO Console**: http://localhost:9001
- **PostgreSQL**: localhost:5432

## 技術詳細

### ディレクトリ構造
```
apps/
├── client/
│   ├── Dockerfile          # 新規作成
│   └── vite.config.js      # プロキシ設定更新
└── server/
    ├── Dockerfile          # 新規作成
    ├── app/main.py         # CORS設定更新
    └── app/utils/s3_client.py  # エンドポイント分離
```

### 環境変数設定
```yaml
# Client
VITE_API_TARGET: http://server:8000

# Server  
DATABASE_URL: postgres://postgres:password@postgres:5432/echo_bird
MINIO_ENDPOINT_URL: http://minio:9000
MINIO_PUBLIC_ENDPOINT_URL: http://localhost:9000
```

## 既存環境への影響

- **後方互換性**: ローカル開発環境はそのまま動作
- **設定変更なし**: 既存の環境変数やポート設定は維持
- **段階的移行**: Docker環境は任意で利用可能

## Test plan

- [x] Docker Compose全サービス起動確認
- [x] Client → Server API通信テスト  
- [x] Server → PostgreSQL接続テスト
- [x] Server → MinIO S3操作テスト
- [x] Browser → MinIOメディアアクセステスト
- [x] ローカル開発環境の互換性確認

🤖 Generated with [Claude Code](https://claude.ai/code)